### PR TITLE
fix: purge cache after publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,6 @@ jobs:
     - run: nix-shell --run publish-component
       if: github.ref == 'refs/heads/master'
       env:
+        CDN_PURGE_CREDENTIALS: ${{ secrets.CDN_PURGE_CREDENTIALS }}
         ENV: production
         SAS_TOKEN: ${{ secrets.SAS_TOKEN }}

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 let
   devops = builtins.fetchGit {
     url = "ssh://git@github.com/fysiweb/devops";
-    rev = "b8653783e9698cf6e174751751f748e20595a694";
+    rev = "f7a9f0790e847027026d14c64a40d7d8380f9041";
   };
   pkgs = import <nixpkgs> {
     overlays = [


### PR DESCRIPTION
fix: https://github.com/fysiweb/flatpickr-web-component/issues/1
before merging, make sure CDN_PURGE_CREDENTIALS is configured in the fysiweb org